### PR TITLE
deviseのエラーを解消する

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,6 +15,8 @@ RUN ["apt-get", "install", "-y", "vim"]
 
 COPY . $APP/
 
+ENV RUBYOPT -EUTF-8
+
 COPY entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]

--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -7,10 +7,11 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins 'localhost:8080'
+    origins 'localhost:3000'
 
     resource '*',
       headers: :any,
-      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+      methods: [:get, :post, :put, :patch, :delete, :options, :head],
+      credentials: true
   end
 end

--- a/backend/config/initializers/devise.rb
+++ b/backend/config/initializers/devise.rb
@@ -298,6 +298,6 @@ Devise.setup do |config|
   # config.sign_in_after_change_password = true
 
   config.jwt do |jwt|
-    jwt.secret = Rails.application.secrets.jwt_secret
+    jwt.secret = Rails.application.credentials.jwt_secret
   end
 end

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -43,10 +43,14 @@ export default {
     '@nuxtjs/auth'
   ],
   auth: {
-    endpoints: {
-      login:  { url: '/users/sign_in' },
-      logout: { url: '/users/sign_out', method: 'delete' },
-      user:   { url: '/users/current' }
+    strategies: {
+      local: {
+        endpoints: {
+          login:  { url: '/users/sign_in' },
+          logout: { url: '/users/sign_out', method: 'delete' },
+          user:   { url: '/users/current' }
+        }
+      }
     }
   },
   axios: {

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -32,6 +32,7 @@
 import Logo from '~/components/Logo.vue'
 
 export default {
+  middleware: ['auth'],
   components: {
     Logo
   }


### PR DESCRIPTION
`backend_1   | Started POST "/api/users/sign_in" for 172.27.0.1 at 2020-04-13 14:16:33 +0000
backend_1   | Processing by SessionsController#create as JSON
backend_1   |   Parameters: {"user"=>{"email"=>"test@example.com", "password"=>"[FILTERED]"}, "session"=>{"user"=>{"email"=>"test@example.com", "password"=>"[FILTERED]"}}}
backend_1   |   User Load (4.0ms)  SELECT "users".* FROM "users" WHERE "users"."email" = $1 ORDER BY "users"."id" ASC LIMIT $2  [["email", "test@example.com"], ["LIMIT", 1]]
backend_1   |   ↳ app/controllers/sessions_controller.rb:3:in `create'
backend_1   | Completed 500 Internal Server Error in 1048ms (ActiveRecord: 7.3ms | Allocations: 7685)
backend_1   | 
backend_1   | 
backend_1   |   
backend_1   | TypeError (no implicit conversion of nil into String):
backend_1   |   
backend_1   | app/controllers/sessions_controller.rb:3:in `create'`

ログインを試みると上記の様なエラーが発生。
session_controllerのprivateメソッド
`def current_token
    request.env['warden-jwt_auth.token']
  end`
がnilを返していることに原因がありそう。